### PR TITLE
docs - enabling saml sso on your ssh keys

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,0 +1,5 @@
+# Contributing
+
+## Authorizing an SSH key for use with SAML single sign-on
+
+To use an SSH key with an organization that uses SAML single sign-on (SSO), you must first authorize the key. Here are the [instructions from GitHub](https://help.github.com/en/github/authenticating-to-github/authorizing-an-ssh-key-for-use-with-saml-single-sign-on).


### PR DESCRIPTION
Added a contributions section to docs including a note on enabling saml sso for your ssh keys.
