### PR TITLE
fix Readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ emphasis on using PyTorch in
 ## Using
 
 VS Code Snippets see:
-[docs/snippets](.docs/../docs/snippets/README.md)
+[docs/snippets](https://github.com/Azure/confidential-ml-utils/blob/master/docs/snippets/README.md)
 
 Compliant logging library see:
-[docs/logging](./docs/logging/README.md)
+[docs/logging](https://github.com/Azure/confidential-ml-utils/blob/master/docs/logging/README.md)
 
 ## Contributing
 

--- a/src/confidential_ml_utils/__init__.py
+++ b/src/confidential_ml_utils/__init__.py
@@ -2,4 +2,4 @@
 Confidential ML utilities.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
The main README.md is also used on the PyPY page so it has to have full not relative urls.