### PR TITLE
add correct throwing, v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ strict compliance and privacy guarantees they provide to their customers. This
 repository contains a set of utilities for confidential ML, with a special
 emphasis on using PyTorch in
 [Azure Machine Learning pipelines](https://aka.ms/pl-concept).
-
+ 
 ## Using
 
 VS Code Snippets see:

--- a/docs/logging/hello-world.py
+++ b/docs/logging/hello-world.py
@@ -18,3 +18,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/docs/logging/prefix-stack-trace.py
+++ b/docs/logging/prefix-stack-trace.py
@@ -65,4 +65,3 @@ if __name__ == "__main__":
         keep_allowed_exceptions()
     except:
         pass
-

--- a/docs/logging/try-except.py
+++ b/docs/logging/try-except.py
@@ -8,7 +8,7 @@ from confidential_ml_utils.exceptions import print_prefixed_stack_trace_and_rais
 try:
     # Import statement which could raise an exception containing sensitive
     # data.
-    import my_custom_library
+    import my_custom_library  # noqa: F401
 except BaseException as e:
     # Output will be:
     #
@@ -21,7 +21,7 @@ except BaseException as e:
 try:
     # Import statement which will never raise an exception containing sensitive
     # data.
-    import another_custom_library
+    import another_custom_library  # noqa: F401
 except BaseException as e:
     # Output will be:
     #

--- a/docs/logging/try-except.py
+++ b/docs/logging/try-except.py
@@ -3,30 +3,30 @@ Simple script with examples of how to directly use the function
 print_prefixed_stack_trace to capture information about failed module imports.
 """
 
-from confidential_ml_utils.exceptions import print_prefixed_stack_trace
+from confidential_ml_utils.exceptions import print_prefixed_stack_trace_and_raise
 
 try:
     # Import statement which could raise an exception containing sensitive
     # data.
     import my_custom_library
-except:
+except BaseException as e:
     # Output will be:
     #
     # SystemLog: Traceback (most recent call last):
     # SystemLog:   File ".\try-except.py", line 10, in <module>
     # SystemLog:     import my_custom_library
     # SystemLog: ModuleNotFoundError: **Exception message scrubbed**
-    print_prefixed_stack_trace()
+    print_prefixed_stack_trace_and_raise(err=e)
 
 try:
     # Import statement which will never raise an exception containing sensitive
     # data.
     import another_custom_library
-except:
+except BaseException as e:
     # Output will be:
     #
     # SystemLog: Traceback (most recent call last):
     # SystemLog:   File ".\try-except.py", line 17, in <module>
     # SystemLog:     import another_custom_library
     # SystemLog: ModuleNotFoundError: No module named 'another_custom_library'
-    print_prefixed_stack_trace(keep_message=True)
+    print_prefixed_stack_trace_and_raise(err=e, keep_message=True)

--- a/src/confidential_ml_utils/__init__.py
+++ b/src/confidential_ml_utils/__init__.py
@@ -2,4 +2,4 @@
 Confidential ML utilities.
 """
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/src/confidential_ml_utils/exceptions.py
+++ b/src/confidential_ml_utils/exceptions.py
@@ -95,7 +95,7 @@ def print_prefixed_stack_trace_and_raise(
     # raise compliant error
     if not err:
         raise
-     elif keep_message or is_exception_allowed(exception, allow_list):
+    elif keep_message or is_exception_allowed(exception, allow_list):
         message = f"{prefix} {err.args[0]}"
         raise type(err)(message) from err
     else:

--- a/src/confidential_ml_utils/exceptions.py
+++ b/src/confidential_ml_utils/exceptions.py
@@ -95,7 +95,7 @@ def print_prefixed_stack_trace_and_raise(
     # raise compliant error
     if not err:
         raise
-    elif keep_message or is_exception_allowed(exception, allow_list):
+     elif keep_message or is_exception_allowed(exception, allow_list):
         message = f"{prefix} {err.args[0]}"
         raise type(err)(message) from err
     else:

--- a/src/tests/test_exceptions.py
+++ b/src/tests/test_exceptions.py
@@ -24,7 +24,7 @@ def test_prefix_stack_trace_preserves_exception_type(message: str, exec_type):
     def function():
         raise exec_type(message)
 
-    with pytest.raises(exec_type) as info:
+    with pytest.raises(exec_type):
         function()
 
     log_lines = file.getvalue()

--- a/src/tests/test_exceptions.py
+++ b/src/tests/test_exceptions.py
@@ -4,7 +4,7 @@ from confidential_ml_utils.exceptions import (
     prefix_stack_trace,
     SCRUB_MESSAGE,
     PREFIX,
-    is_exception_allowed
+    is_exception_allowed,
 )
 from traceback import TracebackException
 
@@ -163,7 +163,7 @@ def test_is_exception_allowed(allow_list, expected_result):
     [
         (True, []),  # unscrub message
         (False, []),  # scrub message
-        (False, ["ValueError"])  # unscrub whitelisted message
+        (False, ["ValueError"]),  # unscrub whitelisted message
     ],
 )
 def test_prefix_stack_trace_throws_correctly(keep_message, allow_list):
@@ -177,7 +177,6 @@ def test_prefix_stack_trace_throws_correctly(keep_message, allow_list):
 
     message = "This is the original exception message"
     e_type = ValueError
-    e_typename = 'ValueError'
 
     @prefix_stack_trace(file, keep_message=keep_message, allow_list=allow_list)
     def function():
@@ -186,10 +185,12 @@ def test_prefix_stack_trace_throws_correctly(keep_message, allow_list):
     with pytest.raises(ValueError) as info:
         function()
 
-    if keep_message == True or is_exception_allowed(TracebackException.from_exception(info.value), allow_list):
+    if keep_message is True or is_exception_allowed(
+        TracebackException.from_exception(info.value), allow_list
+    ):
         assert message in str(info.value)
     else:
         assert SCRUB_MESSAGE in str(info.value)
-    
+
     assert PREFIX in str(info.value)
     assert info.type == e_type

--- a/src/tests/test_exceptions.py
+++ b/src/tests/test_exceptions.py
@@ -3,7 +3,8 @@ import pytest
 from confidential_ml_utils.exceptions import (
     prefix_stack_trace,
     SCRUB_MESSAGE,
-    is_exception_allowed,
+    PREFIX,
+    is_exception_allowed
 )
 from traceback import TracebackException
 
@@ -15,8 +16,7 @@ from traceback import TracebackException
 def test_prefix_stack_trace_preserves_exception_type(message: str, exec_type):
     """
     Verify that the exception type and "scrub message" appear in the
-    prefixed lines. Also, verify that the `prefix_stack_trace` decorator does
-    not modify the type and message of the exception which is thrown.
+    prefixed lines.
     """
     file = io.StringIO()
 
@@ -27,7 +27,6 @@ def test_prefix_stack_trace_preserves_exception_type(message: str, exec_type):
     with pytest.raises(exec_type) as info:
         function()
 
-    assert message in str(info.value)
     log_lines = file.getvalue()
     assert exec_type.__name__ in log_lines
     assert SCRUB_MESSAGE in log_lines
@@ -125,9 +124,9 @@ def test_prefix_stack_trace_nested_exception(keep_message, allow_list, expected_
         (["ModuleNotFound"], True),  # allow_list match error type
         (["arithmetic", "ModuleNotFound"], True),  # allow_list multiple strings
         (["geometry", "algebra"], False),  # allow_list no match
-        (["my_custom_library"], True),
+        (["my_custom_library"], True),  # allow_list match error message
     ],
-)  # allow_list match error message
+)
 def test_prefix_stack_trace_allow_list(allow_list, expected_result):
     file = io.StringIO()
     message = "No module named"
@@ -157,3 +156,40 @@ def test_is_exception_allowed(allow_list, expected_result):
     exception = ModuleNotFoundError("Bingo. It is a pickle.")
     res = is_exception_allowed(TracebackException.from_exception(exception), allow_list)
     assert res == expected_result
+
+
+@pytest.mark.parametrize(
+    "keep_message, allow_list",
+    [
+        (True, []),  # unscrub message
+        (False, []),  # scrub message
+        (False, ["ValueError"])  # unscrub whitelisted message
+    ],
+)
+def test_prefix_stack_trace_throws_correctly(keep_message, allow_list):
+    """
+    After logging the library continues execution by rethrowing an error. The final
+    error thrown is picked up for error reporting by AML. It should be consistent
+    with user's scrubbing choice. Verify that the scrubber preserves the exception type
+    and correctly modifies the exception message
+    """
+    file = io.StringIO()
+
+    message = "This is the original exception message"
+    e_type = ValueError
+    e_typename = 'ValueError'
+
+    @prefix_stack_trace(file, keep_message=keep_message, allow_list=allow_list)
+    def function():
+        raise e_type(message)
+
+    with pytest.raises(ValueError) as info:
+        function()
+
+    if keep_message == True or is_exception_allowed(TracebackException.from_exception(info.value), allow_list):
+        assert message in str(info.value)
+    else:
+        assert SCRUB_MESSAGE in str(info.value)
+    
+    assert PREFIX in str(info.value)
+    assert info.type == e_type


### PR DESCRIPTION
Adding logic to correctly throw at the end:
- will add compliant prefix to thrown message which will allow AML to correctly report the error
- will scrub the thrown message according to user preference
