### PR TITLE
Remove category from _log signature

### DIFF
--- a/src/confidential_ml_utils/logging.py
+++ b/src/confidential_ml_utils/logging.py
@@ -54,7 +54,16 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
     def __init__(self, name: str):
         super().__init__(name)  # type: ignore
 
-    def _log(self, level, msg, category, args, **kwargs):
+    def _log(self, level, msg, args, **kwargs):
+        """
+        Note: Signature here matches superclass `_log` to avoid mismatch issues.
+        The `category` is thus assumed to be in `kwargs` and is popped
+        """
+        try:
+            category = kwargs.pop("category")
+        except KeyError:
+            raise TypeError(f"Required argument `category` not provided")
+
         p = ""
         if category == DataCategory.PUBLIC:
             p = get_prefix()
@@ -74,7 +83,8 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
             logger.debug("public data", category=DataCategory.PUBLIC)
         """
         if self.isEnabledFor(DEBUG):
-            self._log(DEBUG, msg, category, args, **kwargs)
+            kwargs['category'] = category
+            self._log(DEBUG, msg, args, **kwargs)
 
     def info(
         self, msg: str, category: DataCategory = DataCategory.PRIVATE, *args, **kwargs
@@ -88,7 +98,8 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
             logger.info("public data", category=DataCategory.PUBLIC)
         """
         if self.isEnabledFor(INFO):
-            self._log(INFO, msg, category, args, **kwargs)
+            kwargs['category'] = category
+            self._log(INFO, msg, args, **kwargs)
 
     def warning(
         self, msg: str, category: DataCategory = DataCategory.PRIVATE, *args, **kwargs
@@ -102,7 +113,8 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
             logger.warning("public data", category=DataCategory.PUBLIC)
         """
         if self.isEnabledFor(WARNING):
-            self._log(WARNING, msg, category, args, **kwargs)
+            kwargs['category'] = category
+            self._log(WARNING, msg, args, **kwargs)
 
     def warn(
         self, msg: str, category: DataCategory = DataCategory.PRIVATE, *args, **kwargs
@@ -126,7 +138,8 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
             logger.error("public data", category=DataCategory.PUBLIC)
         """
         if self.isEnabledFor(ERROR):
-            self._log(ERROR, msg, category, args, **kwargs)
+            kwargs['category'] = category
+            self._log(ERROR, msg, args, **kwargs)
 
     def critical(
         self, msg: str, category: DataCategory = DataCategory.PRIVATE, *args, **kwargs
@@ -140,7 +153,8 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
             logger.critical("public data", category=DataCategory.PUBLIC)
         """
         if self.isEnabledFor(CRITICAL):
-            self._log(CRITICAL, msg, category, args, **kwargs)
+            kwargs['category'] = category
+            self._log(CRITICAL, msg, args, **kwargs)
 
 
 _logging_basic_config_set_warning = """

--- a/src/confidential_ml_utils/logging.py
+++ b/src/confidential_ml_utils/logging.py
@@ -83,8 +83,7 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
             logger.debug("public data", category=DataCategory.PUBLIC)
         """
         if self.isEnabledFor(DEBUG):
-            kwargs["category"] = category
-            self._log(DEBUG, msg, args, **kwargs)
+            self._log(DEBUG, msg, args, category=category, **kwargs)
 
     def info(
         self, msg: str, category: DataCategory = DataCategory.PRIVATE, *args, **kwargs
@@ -98,8 +97,7 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
             logger.info("public data", category=DataCategory.PUBLIC)
         """
         if self.isEnabledFor(INFO):
-            kwargs["category"] = category
-            self._log(INFO, msg, args, **kwargs)
+            self._log(INFO, msg, args, category=category, **kwargs)
 
     def warning(
         self, msg: str, category: DataCategory = DataCategory.PRIVATE, *args, **kwargs
@@ -113,8 +111,7 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
             logger.warning("public data", category=DataCategory.PUBLIC)
         """
         if self.isEnabledFor(WARNING):
-            kwargs["category"] = category
-            self._log(WARNING, msg, args, **kwargs)
+            self._log(WARNING, msg, args, category=category, **kwargs)
 
     def warn(
         self, msg: str, category: DataCategory = DataCategory.PRIVATE, *args, **kwargs
@@ -138,8 +135,7 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
             logger.error("public data", category=DataCategory.PUBLIC)
         """
         if self.isEnabledFor(ERROR):
-            kwargs["category"] = category
-            self._log(ERROR, msg, args, **kwargs)
+            self._log(ERROR, msg, args, category=category, **kwargs)
 
     def critical(
         self, msg: str, category: DataCategory = DataCategory.PRIVATE, *args, **kwargs
@@ -153,8 +149,7 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
             logger.critical("public data", category=DataCategory.PUBLIC)
         """
         if self.isEnabledFor(CRITICAL):
-            kwargs["category"] = category
-            self._log(CRITICAL, msg, args, **kwargs)
+            self._log(CRITICAL, msg, args, category=category, **kwargs)
 
 
 _logging_basic_config_set_warning = """

--- a/src/confidential_ml_utils/logging.py
+++ b/src/confidential_ml_utils/logging.py
@@ -56,14 +56,11 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
 
     def _log(self, level, msg, args, **kwargs):
         """
-        Note: Signature here matches superclass `_log` to avoid mismatch issues.
-        The `category` is thus assumed to be in `kwargs` and is popped
+        Note: Signature here consistent with superclass `_log` to avoid
+        mismatch issues. We pop `category` from `kwargs`, defaulting to
+        `DataCategory.PRIVATE` if not provided.
         """
-        try:
-            category = kwargs.pop("category")
-        except KeyError:
-            raise TypeError("Required argument `category` not provided")
-
+        category = kwargs.pop("category", DataCategory.PRIVATE)
         p = ""
         if category == DataCategory.PUBLIC:
             p = get_prefix()

--- a/src/confidential_ml_utils/logging.py
+++ b/src/confidential_ml_utils/logging.py
@@ -83,7 +83,7 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
             logger.debug("public data", category=DataCategory.PUBLIC)
         """
         if self.isEnabledFor(DEBUG):
-            kwargs['category'] = category
+            kwargs["category"] = category
             self._log(DEBUG, msg, args, **kwargs)
 
     def info(
@@ -98,7 +98,7 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
             logger.info("public data", category=DataCategory.PUBLIC)
         """
         if self.isEnabledFor(INFO):
-            kwargs['category'] = category
+            kwargs["category"] = category
             self._log(INFO, msg, args, **kwargs)
 
     def warning(
@@ -113,7 +113,7 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
             logger.warning("public data", category=DataCategory.PUBLIC)
         """
         if self.isEnabledFor(WARNING):
-            kwargs['category'] = category
+            kwargs["category"] = category
             self._log(WARNING, msg, args, **kwargs)
 
     def warn(
@@ -138,7 +138,7 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
             logger.error("public data", category=DataCategory.PUBLIC)
         """
         if self.isEnabledFor(ERROR):
-            kwargs['category'] = category
+            kwargs["category"] = category
             self._log(ERROR, msg, args, **kwargs)
 
     def critical(
@@ -153,7 +153,7 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
             logger.critical("public data", category=DataCategory.PUBLIC)
         """
         if self.isEnabledFor(CRITICAL):
-            kwargs['category'] = category
+            kwargs["category"] = category
             self._log(CRITICAL, msg, args, **kwargs)
 
 

--- a/src/confidential_ml_utils/logging.py
+++ b/src/confidential_ml_utils/logging.py
@@ -62,7 +62,7 @@ class ConfidentialLogger(logging.getLoggerClass()):  # type: ignore
         try:
             category = kwargs.pop("category")
         except KeyError:
-            raise TypeError(f"Required argument `category` not provided")
+            raise TypeError("Required argument `category` not provided")
 
         p = ""
         if category == DataCategory.PUBLIC:


### PR DESCRIPTION
Removing `category`  from `_log` signature to be consistent with superclass (logging.getLoggerClass()). This is to avoid signature mismatch issues that can arise when - for example - using pytest in combination with our logger.

Concretely, the change is to pop category from kwargs, and to throw if not present.